### PR TITLE
Enable resizing video player via inline styles

### DIFF
--- a/style.css
+++ b/style.css
@@ -12,3 +12,12 @@ body {
   height: 90px;
   object-fit: cover;
 }
+
+/* The video container size can be controlled via inline style */
+.video-container {
+  position: relative;
+}
+.video-container > * {
+  width: 100%;
+  height: 100%;
+}

--- a/video.html
+++ b/video.html
@@ -12,7 +12,8 @@
 <body class="bg-light">
   <div class="container py-4">
     <h1 class="text-center mb-4">Video</h1>
-    <div id="player" class="video-container d-flex justify-content-center"></div>
+      <!-- Adjust the width and height via the style attribute below -->
+      <div id="player" class="video-container d-flex justify-content-center" style="width: 640px; height: 360px;"></div>
     <div id="metadata" class="mt-4"></div>
   </div>
   <script src="script.js"></script>


### PR DESCRIPTION
## Summary
- allow customizing video player size in `video.html` by editing the style attribute of the `div`
- ensure any embedded video fits the container with new CSS rules

## Testing
- `npx --version`

------
https://chatgpt.com/codex/tasks/task_e_6850c6eb996083208a9b79a94a6efb0e