### PR TITLE
Add full-size screenshot viewer

### DIFF
--- a/script.js
+++ b/script.js
@@ -166,6 +166,7 @@ function loadVideo(element) {
       }
       if (screenshotContainer) {
         screenshotContainer.innerHTML = buildScreenshotsHtml(data.screen_shots);
+        setupScreenshotViewer(screenshotContainer);
       }
     })
     // メタデータ取得失敗時の処理
@@ -223,10 +224,29 @@ function buildScreenshotsHtml(urls) {
   let html = '<h2 class="h4 mb-3">Screenshots</h2>';
   html += '<div class="thumbnail-row d-flex flex-wrap">';
   urls.forEach(url => {
-    html += `<img src="${url}" alt="Screenshot" class="img-thumbnail me-2 mb-2">`;
+    html += `<img src="${url}" data-full-src="${url}" alt="Screenshot" class="img-thumbnail screenshot-thumb me-2 mb-2">`;
   });
   html += '</div>';
   return html;
+}
+
+// スクリーンショットのクリックでモーダル表示を行う
+function setupScreenshotViewer(container) {
+  container.addEventListener('click', event => {
+    const target = event.target;
+    if (target.tagName === 'IMG') {
+      const src = target.dataset.fullSrc || target.src;
+      const modalImg = document.getElementById('screenshotModalImg');
+      if (modalImg) {
+        modalImg.src = src;
+        const modalElement = document.getElementById('screenshotModal');
+        if (modalElement) {
+          const modal = new bootstrap.Modal(modalElement);
+          modal.show();
+        }
+      }
+    }
+  });
 }
 
 // 埋め込みプレイヤーを初期化

--- a/style.css
+++ b/style.css
@@ -13,6 +13,10 @@ body {
   object-fit: cover;
 }
 
+.screenshot-thumb {
+  cursor: pointer;
+}
+
 .thumbnail-row a {
   width: 160px;
   text-decoration: none;

--- a/video.html
+++ b/video.html
@@ -21,6 +21,16 @@
 
     <div id="metadata" class="mt-4"></div>
     <div id="screenshots" class="mt-4"></div>
+    <!-- Modal for full-size screenshot -->
+    <div class="modal fade" id="screenshotModal" tabindex="-1" aria-hidden="true">
+      <div class="modal-dialog modal-dialog-centered modal-lg">
+        <div class="modal-content">
+          <div class="modal-body p-0">
+            <img id="screenshotModalImg" src="" class="img-fluid" alt="Screenshot">
+          </div>
+        </div>
+      </div>
+    </div>
   </div>
   <script src="script.js"></script>
   <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/js/bootstrap.bundle.min.js"></script>


### PR DESCRIPTION
## Summary
- enable image modal when clicking a screenshot thumbnail
- mark screenshot thumbnails as clickable
- include Bootstrap modal in `video.html`

## Testing
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6850f3e469688320908e18f9d4338790